### PR TITLE
Add setValue() function to allow you to change slider value programatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,10 @@ debugTouchArea        | bool     | Yes      | false                     | Set th
 
 ---
 
+## Set Value Programatically
+
+If you put ref='slider' on your <Slider> component, you can change the current value with `this.refs.slider.setValue(newValue);`
+
+---
+
 **MIT Licensed**


### PR DESCRIPTION
I'm using the slider as a video player scrubber, so I needed to increment the slider's value in code every second. This function allows me to do so. I added `this.state.sliding` so that calls to `setValue()` while the user is dragging the thumb are ignored. I also go ahead and set the slider to the `maximumValue` if the value passed to `setValue()` is within 1 or greater than the `maximumValue`.