### PR TITLE
Give containerSize, trackSize and thumbSize default values

### DIFF
--- a/Slider.js
+++ b/Slider.js
@@ -115,9 +115,9 @@ var Slider = React.createClass({
   },
   getInitialState() {
     return {
-      containerSize: {},
-      trackSize: {},
-      thumbSize: {},
+      containerSize: { width: 0, height: 0 },
+      trackSize: { width: 0, height: 0 },
+      thumbSize: { width: 0, height: 0 },
       previousLeft: 0,
       value: this.props.value,
     };


### PR DESCRIPTION
Without default values, and when not debugging in Chrome, the app will crash with the following error:

*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Invalid number value (NaN) in JSON write'

This happens on react-native 0.14-rc