### PR TITLE
Peer dependencies are broken, prefer not to use at all

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
   },
   "dependencies": {
   },
-  "peerDependencies": {
-    "react-native": ">=0.11.0 || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc"
-  },
   "devDependencies": {
     "babel-eslint": "^3.1.15",
     "eslint": "^0.23.0",


### PR DESCRIPTION
Found this annoying when installing the project on a version of react-native that wasn't listed in the peerDependencies list :) Unfortunately peerDependencies are still super broken with npm..