### PR TITLE
Remove componentWillReceiveProps so that not controlled

### DIFF
--- a/Slider.js
+++ b/Slider.js
@@ -144,9 +144,6 @@ var Slider = React.createClass({
       onPanResponderTerminate: this._handlePanResponderEnd,
     });
   },
-  componentWillReceiveProps: function(nextProps) {
-    this.setState({value: nextProps.value});
-  },
   render() {
     var {
       minimumTrackTintColor,


### PR DESCRIPTION
See: jeanregisser/react-native-slider#23

`SliderIOS` interprets `value` as an initial value only. I'm not 100% sure it's the right move, but I've removed `componentWillReceiveProps` so that it may match SliderIOS behavior more closely.