### PR TITLE
Making react-native-slider 0.25+ compatible

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
   Animated,
   PropTypes,
   StyleSheet,
   PanResponder,
   View
-} = React;
+} = require('react-native');
 var shallowCompare = require('react-addons-shallow-compare');
 var styleEqual = require('style-equal');
 


### PR DESCRIPTION
react-native@0.25 deprecates `const React = require('react-native')` and asks you to use `const React = require('react')` instead. Just did that.