### PR TITLE
added possibility to hook thumb creation

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -162,6 +162,11 @@ var Slider = React.createClass({
     * Used to configure the animation parameters.  These are the same parameters in the Animated library.
     */
     animationConfig : PropTypes.object,
+
+    /**
+     * Used to wrap thumb view in another component, or to replace it with a custom view .
+     */
+    createThumbMiddleware : PropTypes.func,
   },
   getInitialState() {
     return {
@@ -223,6 +228,12 @@ var Slider = React.createClass({
       || !styleEqual(this.props.trackStyle, nextProps.trackStyle)
       || !styleEqual(this.props.thumbStyle, nextProps.thumbStyle);
   },
+
+  _createWrappedThumbView(view) {
+    const { createThumbMiddleware } = this.props;
+    return createThumbMiddleware ? createThumbMiddleware(view) : view;
+  },
+
   render() {
     var {
       minimumValue,
@@ -268,10 +279,18 @@ var Slider = React.createClass({
         <Animated.View
           onLayout={this._measureThumb}
           style={[
-            {backgroundColor: thumbTintColor, marginTop: -(trackSize.height + thumbSize.height) / 2},
+            {marginTop: -(trackSize.height + thumbSize.height) / 2},
             mainStyles.thumb, thumbStyle, {left: thumbLeft, ...valueVisibleStyle}
           ]}
-        />
+        >
+          {this._createWrappedThumbView(<View
+            style={[
+              {backgroundColor: thumbTintColor},
+              mainStyles.thumb,
+              thumbStyle,
+            ]}
+          />)}
+        </Animated.View>
         <View
           style={[defaultStyles.touchArea, touchOverflowStyle]}
           {...this._panResponder.panHandlers}>


### PR DESCRIPTION
Hey, this fix make thumb creation much more flexible, by adding possibility to provide custom views as thums

```
<Slider
          ....
          createThumbMiddleware={view => (
            <ToolTip
              visible={toolTipVisible}
              text="SOME TEXT"
            >
              {view}
            </ToolTip>
          )}
        />
```
