### PR TITLE
Set rendertohardwaretextureandroid

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -263,10 +263,14 @@ var Slider = React.createClass({
       <View {...other} style={[mainStyles.container, style]} onLayout={this._measureContainer}>
         <View
           style={[{backgroundColor: maximumTrackTintColor,}, mainStyles.track, trackStyle]}
+          renderToHardwareTextureAndroid={true}
           onLayout={this._measureTrack} />
-        <Animated.View style={[mainStyles.track, trackStyle, minimumTrackStyle]} />
+        <Animated.View
+          renderToHardwareTextureAndroid={true}
+          style={[mainStyles.track, trackStyle, minimumTrackStyle]} />
         <Animated.View
           onLayout={this._measureThumb}
+          renderToHardwareTextureAndroid={true}
           style={[
             {backgroundColor: thumbTintColor},
             mainStyles.thumb, thumbStyle,
@@ -280,6 +284,7 @@ var Slider = React.createClass({
           ]}
         />
         <View
+          renderToHardwareTextureAndroid={true}
           style={[defaultStyles.touchArea, touchOverflowStyle]}
           {...this._panResponder.panHandlers}>
           {debugTouchArea === true && this._renderDebugThumbTouchRect(thumbLeft)}


### PR DESCRIPTION
This seems to make dragging the slider more responsive on android
devices.  These views tend to be small so the memory footprint is hopefully small.  Thoughts?