### PR TITLE
Make thumb center reflect the value

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -239,9 +239,10 @@ var Slider = React.createClass({
     } = this.props;
     var {value, containerSize, trackSize, thumbSize, allMeasured} = this.state;
     var mainStyles = styles || defaultStyles;
+    var halfThumbWidth = thumbSize.width / 2;
     var thumbLeft = value.interpolate({
         inputRange: [minimumValue, maximumValue],
-        outputRange: [0, containerSize.width - thumbSize.width],
+        outputRange: [0 - halfThumbWidth, containerSize.width - thumbSize.width + halfThumbWidth],
         //extrapolate: 'clamp',
       });
     var valueVisibleStyle = {};


### PR DESCRIPTION
Essentially this makes it so that the start and end values correspond to the center of the thumb instead of the left or right side of the thumb.

It should be this

```
// min value
(  |--)------------------|


// max value
-------------------(--|  )
```
instead of this

```
// min value
|(----)------------------|


// max value
-------------------(----)|
```

How to understand the above illustration:
```
// the start or end of the track
| 
// the left side of the thumb
(
// the right side of the thumb
)
// the track
----
```