### PR TITLE
correct position logic of track and thumb

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -257,7 +257,6 @@ var Slider = React.createClass({
     }
 
     var minimumTrackStyle = {
-      position: 'absolute',
       width: Animated.add(thumbLeft, thumbSize.width / 2),
       marginTop: -trackSize.height,
       backgroundColor: minimumTrackTintColor,
@@ -275,12 +274,15 @@ var Slider = React.createClass({
         <Animated.View
           onLayout={this._measureThumb}
           style={[
-            {backgroundColor: thumbTintColor},
+            {
+              backgroundColor: thumbTintColor,
+              left: 0,
+              top: containerSize.height / 2 - thumbSize.height / 2
+            },
             mainStyles.thumb, thumbStyle,
             {
               transform: [
-                { translateX: thumbLeft },
-                { translateY: -(trackSize.height + thumbSize.height) / 2 }
+                { translateX: thumbLeft }
               ],
               ...valueVisibleStyle
             }


### PR DESCRIPTION
When I cloned the project and run the example, everything works correctly! However, in my personal object, the `track` & `thumb` part are higher than expected.

Here I will show some screenshot:

<img width="269" alt="2017-03-16 3 45 39" src="https://cloud.githubusercontent.com/assets/8046480/23989176/7c8dacda-0a6c-11e7-982d-711b85c4b158.png">
<img width="372" alt="2017-03-16 3 52 48" src="https://cloud.githubusercontent.com/assets/8046480/23989193/890b1e98-0a6c-11e7-8a39-4eb32e6556e2.png">


My code is almost the same with **Examples**, but got incorrect result.


I read through the code and try to solve my problem:

1. `minimumTrack` use `marginTop` to get a correct `Y` axis coordinates, there is no need to set `absolute` to `minimumTrack`.
2. `thumb` use `transform` to get correct `X|Y` axis coordinates, and I preserve the `X` part and use `top` value instead.

I tested the `Example`'s ios part and all work correctly. And I run my own project, position is correct now.

@jeanregisser Hope you can review the pr soon.