### PR TITLE
Remove dependency upon deprecated View.propTypes

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -10,7 +10,8 @@ import {
   StyleSheet,
   PanResponder,
   View,
-  Easing
+  Easing,
+  ViewPropTypes
 } from "react-native";
 
 import PropTypes from 'prop-types';
@@ -130,17 +131,17 @@ export default class Slider extends PureComponent {
     /**
      * The style applied to the slider container.
      */
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
 
     /**
      * The style applied to the track.
      */
-    trackStyle: View.propTypes.style,
+    trackStyle: ViewPropTypes.style,
 
     /**
      * The style applied to the thumb.
      */
-    thumbStyle: View.propTypes.style,
+    thumbStyle: ViewPropTypes.style,
 
     /**
      * Sets an image for the thumb.


### PR DESCRIPTION
`View.propTypes.style` has been replaced by `ViewStylePropTypes`.

This PR updates the references and silences a deprecation warning in React Native 0.46+.