### PR TITLE
 Add ability to display text on the thumb

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ style                 | [style](http://facebook.github.io/react-native/docs/view
 trackStyle            | [style](http://facebook.github.io/react-native/docs/view.html#style)    | Yes      |                           | The style applied to the track
 thumbStyle            | [style](http://facebook.github.io/react-native/docs/view.html#style)    | Yes      |                           | The style applied to the thumb
 thumbImage            | [source](http://facebook.github.io/react-native/docs/image.html#source)    | Yes      |                           | Sets an image for the thumb.
+thumbText             | string   | Yes      | undefined                  | Sets text for the thumb, if both image and text are present, image is displayed
+thumbTextStyle        | [style](http://facebook.github.io/react-native/docs/text.html#style)   | Yes      | undefined                  | The style applied to thumb text
 debugTouchArea        | bool     | Yes      | false                     | Set this to true to visually see the thumb touch rect in green.
 animateTransitions    | bool     | Yes      | false                     | Set to true if you want to use the default 'spring' animation
 animationType         | string   | Yes      | 'timing'                  | Set to 'spring' or 'timing' to use one of those two types of animations with the default [animation properties](https://facebook.github.io/react-native/docs/animations.html).

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -1,8 +1,8 @@
-'use strict';
+
 
 import React, {
   PureComponent,
-} from "react";
+} from 'react';
 
 import {
   Animated,
@@ -13,7 +13,7 @@ import {
   Easing,
   ViewPropTypes,
   Text
-} from "react-native";
+} from 'react-native';
 
 import PropTypes from 'prop-types';
 
@@ -202,6 +202,8 @@ export default class Slider extends PureComponent {
   };
 
   componentWillMount() {
+    this._checkForInvalidValue(this.props.value);
+
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: this._handleStartShouldSetPanResponder,
       onMoveShouldSetPanResponder: this._handleMoveShouldSetPanResponder,
@@ -215,6 +217,8 @@ export default class Slider extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     var newValue = nextProps.value;
+
+    this._checkForInvalidValue(newValue);
 
     if (this.props.value !== newValue) {
       if (this.props.animateTransitions) {
@@ -385,7 +389,7 @@ export default class Slider extends PureComponent {
         trackSize: this._trackSize,
         thumbSize: this._thumbSize,
         allMeasured: true,
-      })
+      });
     }
   };
 
@@ -524,11 +528,21 @@ export default class Slider extends PureComponent {
     }
 
     if (thumbText) {
-      return <Text style={thumbTextStyle}>{thumbText}</Text>
+      return <Text style={thumbTextStyle}>{thumbText}</Text>;
     }
 
-    return null
+    return null;
   };
+
+  _checkForInvalidValue = value => {
+    const { minimumValue, maximumValue } = this.props;
+    
+    if (value > maximumValue || value < minimumValue) {
+      console.error(
+        `Invalid prop value ${value} provided, it should be between min: ${minimumValue} and max: ${maximumValue}`
+      );
+    }
+  }
 }
 
 var defaultStyles = StyleSheet.create({

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -239,6 +239,11 @@ export default class Slider extends PureComponent {
       trackStyle,
       thumbStyle,
       debugTouchArea,
+      thumbText,
+      thumbTextStyle,
+      thumbTouchSize,
+      onValueChange,
+      animationType,
       ...other
     } = this.props;
     var {value, containerSize, trackSize, thumbSize, allMeasured} = this.state;

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -11,7 +11,8 @@ import {
   PanResponder,
   View,
   Easing,
-  ViewPropTypes
+  ViewPropTypes,
+  Text
 } from "react-native";
 
 import PropTypes from 'prop-types';
@@ -149,6 +150,16 @@ export default class Slider extends PureComponent {
     thumbImage: Image.propTypes.source,
 
     /**
+     * Sets text for the thumb, if both image and text are present, image is displayed
+     */
+    thumbText: PropTypes.string,
+
+    /**
+     * The style applied to thumb text
+     */
+    thumbTextStyle: Text.propTypes.style,
+
+    /**
      * Set this to true to visually see the thumb touch rect in green.
      */
     debugTouchArea: PropTypes.bool,
@@ -275,7 +286,7 @@ export default class Slider extends PureComponent {
             }
           ]}
         >
-          {this._renderThumbImage()}
+          {this._renderThumbContents()}
         </Animated.View>
         <View
           renderToHardwareTextureAndroid={true}
@@ -500,12 +511,18 @@ export default class Slider extends PureComponent {
     );
   };
 
-  _renderThumbImage = () => {
-    var {thumbImage} = this.props;
+  _renderThumbContents = () => {
+    var {thumbImage, thumbText, thumbTextStyle} = this.props;
 
-    if (!thumbImage) return;
+    if (thumbImage) {
+      return <Image source={thumbImage} />;
+    }
 
-    return <Image source={thumbImage} />;
+    if (thumbText) {
+      return <Text style={thumbTextStyle}>{thumbText}</Text>
+    }
+
+    return null
   };
 }
 
@@ -523,6 +540,8 @@ var defaultStyles = StyleSheet.create({
     width: THUMB_SIZE,
     height: THUMB_SIZE,
     borderRadius: THUMB_SIZE / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   touchArea: {
     position: 'absolute',


### PR DESCRIPTION
Added two props: 

- thumbText - Sets text for the thumb, if both image and text are present, image is displayed
- thumbTextStyle - The style applied to thumb text

This is helpful for this:
![image](https://user-images.githubusercontent.com/12987425/32096539-d189bc86-bb17-11e7-9119-c976ecc5408b.png)
