### PR TITLE
Support multiple thumbs

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -52,15 +52,24 @@ var DEFAULT_ANIMATION_CONFIGS = {
 export default class Slider extends PureComponent {
   static propTypes = {
     /**
-     * Initial value of the slider. The value should be between minimumValue
+     * Initial value of the slider, or array of initial values for all thumbs.
+     * The value should be between minimumValue
      * and maximumValue, which default to 0 and 1 respectively.
      * Default value is 0.
      *
      * *This is not a controlled component*, e.g. if you don't update
      * the value, the component won't be reset to its inital value.
      */
-    value: PropTypes.number,
-
+    value: function(props, propName, componentName) {
+      if (props[propName] &&
+        typeof props[propName] !== 'number' &&
+        !Array.isArray(props[propName])) {
+        return new Error(
+            `Invalid prop ${propName} supplied to ${componentName}. This prop must be a number, or an array of numbers.`
+        );
+      }
+    },
+ 
     /**
      * If true the user won't be able to move the slider.
      * Default value is false.
@@ -82,19 +91,32 @@ export default class Slider extends PureComponent {
      * (maximumValue - minimumValue). Default value is 0.
      */
     step: PropTypes.number,
-
+    
     /**
      * The color used for the track to the left of the button. Overrides the
      * default blue gradient image.
+     * @deprecated Please use <code>trackHighlightColor</code>
      */
     minimumTrackTintColor: PropTypes.string,
-
+    
     /**
      * The color used for the track to the right of the button. Overrides the
      * default blue gradient image.
+     * @deprecated Please use <code>trackColor</code>
      */
     maximumTrackTintColor: PropTypes.string,
 
+    /**
+     * The color used for the track.
+     */
+    trackColor: PropTypes.string,
+
+    /**
+     * The color used for the selected portion of the track. Left of single button
+     * or in between multi buttons.
+     */
+    trackHighlightColor: PropTypes.string,
+    
     /**
      * The color used for the thumb.
      */
@@ -142,11 +164,16 @@ export default class Slider extends PureComponent {
      * The style applied to the thumb.
      */
     thumbStyle: ViewPropTypes.style,
-
+    
     /**
-     * Sets an image for the thumb.
+     * Sets an image for the thumb, or array of images for multiple thumbs.
      */
-    thumbImage: Image.propTypes.source,
+    thumbImage: PropTypes.array,
+    
+    /**
+     * Sets a view for the thumb, or array of views for multiple thumbs.
+     */
+    thumbView: PropTypes.array,
 
     /**
      * Set this to true to visually see the thumb touch rect in green.
@@ -171,24 +198,59 @@ export default class Slider extends PureComponent {
 
   static defaultProps = {
     value: 0,
+    trackHighlightColor: '#3f3f3f',
+    trackColor: '#b3b3b3',
     minimumValue: 0,
     maximumValue: 1,
     step: 0,
-    minimumTrackTintColor: '#3f3f3f',
-    maximumTrackTintColor: '#b3b3b3',
     thumbTintColor: '#343434',
     thumbTouchSize: {width: 40, height: 40},
     debugTouchArea: false,
     animationType: 'timing'
   };
 
-  state = {
-    containerSize: {width: 0, height: 0},
-    trackSize: {width: 0, height: 0},
-    thumbSize: {width: 0, height: 0},
-    allMeasured: false,
-    value: new Animated.Value(this.props.value),
-  };
+  constructor(props) {
+    super(props);
+    
+    this._onAnimatedValueChange = this._onAnimatedValueChange.bind(this);
+
+    this.state = {
+      containerSize: {width: 0, height: 0},
+      trackSize: {width: 0, height: 0},
+      thumbSize: {width: 0, height: 0},
+      allMeasured: false,
+      value: this._prepareValuesFromProps(this.props.value),
+      minThumbValue: new Animated.Value(0),
+      maxThumbValue: new Animated.Value(0),
+      interpolatedThumbValues: [],
+    };
+  }
+
+  _prepareValuesFromProps(value) {
+
+    let normalized = [];
+
+    if (!Array.isArray(value)) {
+      value = [value];
+    }
+    let valueCount = value.length;
+
+    for (let i = 0; i < valueCount; i++) {
+      let newValue = value[i];
+      if (typeof newValue !== 'number') {
+        newValue = i > 0 ? normalized[i - 1] : 0;
+      } 
+      newValue = Math.max(Math.min(newValue, this.props.maximumValue), this.props.minimumValue)
+      normalized.push(newValue);
+    }
+
+    for (let i = 0; i < normalized.length; i++) {
+      normalized[i] = new Animated.Value(normalized[i]);
+      normalized[i].addListener(this._onAnimatedValueChange);
+    }
+
+    return normalized;
+  }
 
   componentWillMount() {
     this._panResponder = PanResponder.create({
@@ -203,14 +265,29 @@ export default class Slider extends PureComponent {
   };
 
   componentWillReceiveProps(nextProps) {
-    var newValue = nextProps.value;
+    var oldValues = this.props.value;
+    var newValues = nextProps.value;
+    
+    if (!Array.isArray(newValues))
+      newValues = [newValues];
 
-    if (this.props.value !== newValue) {
-      if (this.props.animateTransitions) {
-        this._setCurrentValueAnimated(newValue);
-      }
-      else {
-        this._setCurrentValue(newValue);
+    if (newValues.length !== this.state.value.length) {
+      // Different number of thumbs
+      this.setState({
+        value: this._prepareValuesFromProps(nextProps.value)
+      });
+    } else {
+      // Just update/animate current thumb values
+      for (let i = 0; i < newValues.length; i++) {
+        let val = newValues[i];
+        if (typeof val === 'number' && val !== newValues[i]) {
+          if (this.props.animateTransitions) {
+            this._setCurrentValueAnimated(val, i);
+          }
+          else {
+            this._setCurrentValue(val, i);
+          }
+        }
       }
     }
   };
@@ -221,8 +298,9 @@ export default class Slider extends PureComponent {
       maximumValue,
       minimumTrackTintColor,
       maximumTrackTintColor,
+      trackColor,
+      trackHighlightColor,
       thumbTintColor,
-      thumbImage,
       styles,
       style,
       trackStyle,
@@ -230,37 +308,70 @@ export default class Slider extends PureComponent {
       debugTouchArea,
       ...other
     } = this.props;
+
     var {value, containerSize, trackSize, thumbSize, allMeasured} = this.state;
+
     var mainStyles = styles || defaultStyles;
-    var thumbLeft = value.interpolate({
+
+    let thumbValues = this.state.interpolatedThumbValues = value.map(v => v.interpolate({
       inputRange: [minimumValue, maximumValue],
       outputRange: [0, containerSize.width - thumbSize.width],
       //extrapolate: 'clamp',
-    });
+    }));
+
     var valueVisibleStyle = {};
     if (!allMeasured) {
       valueVisibleStyle.opacity = 0;
     }
 
-    var minimumTrackStyle = {
-      position: 'absolute',
-      width: Animated.add(thumbLeft, thumbSize.width / 2),
-      backgroundColor: minimumTrackTintColor,
-      ...valueVisibleStyle
-    };
-
     var touchOverflowStyle = this._getTouchOverflowStyle();
 
-    return (
-      <View {...other} style={[mainStyles.container, style]} onLayout={this._measureContainer}>
-        <View
-          style={[{backgroundColor: maximumTrackTintColor,}, mainStyles.track, trackStyle]}
-          renderToHardwareTextureAndroid={true}
-          onLayout={this._measureTrack} />
+    let children = [];
+
+    let trackHighlightStyle;
+
+    if (thumbValues.length > 1) {
+
+      let flatValues = thumbValues.map(x => x.__getValue());
+      this.state.minThumbValue = new Animated.Value(Math.min.apply(Math, flatValues));
+      this.state.maxThumbValue = new Animated.Value(Math.max.apply(Math, flatValues));
+
+      trackHighlightStyle = {
+        position: 'absolute',
+        left: Animated.add(this.state.minThumbValue, thumbSize.width / 2),
+        width: Animated.add(
+          Animated.multiply(this.state.minThumbValue, -1), 
+          this.state.maxThumbValue
+        ),
+        marginTop: -trackSize.height,
+        backgroundColor: minimumTrackTintColor || trackHighlightColor,
+        ...valueVisibleStyle
+      };
+
+    } else {
+      trackHighlightStyle = {
+        position: 'absolute',
+        left: 0,
+        width: Animated.add(thumbLeft, thumbSize.width / 2),
+        marginTop: -trackSize.height,
+        backgroundColor: minimumTrackTintColor || trackHighlightColor,
+        ...valueVisibleStyle
+      };
+    }
+
+    children.push(
+      <Animated.View 
+        key={'track_highlight'}
+        renderToHardwareTextureAndroid={true}
+        style={[mainStyles.track, trackStyle, trackHighlightStyle]} />
+    );
+
+    for (let i = 0; i < thumbValues.length; i++) {
+      let thumb = thumbValues[i];
+
+      children.push(
         <Animated.View
-          renderToHardwareTextureAndroid={true}
-          style={[mainStyles.track, trackStyle, minimumTrackStyle]} />
-        <Animated.View
+          key={'thumb_' + i}
           onLayout={this._measureThumb}
           renderToHardwareTextureAndroid={true}
           style={[
@@ -268,21 +379,42 @@ export default class Slider extends PureComponent {
             mainStyles.thumb, thumbStyle,
             {
               transform: [
-                { translateX: thumbLeft },
+                { translateX: thumb },
                 { translateY: 0 }
               ],
               ...valueVisibleStyle
             }
           ]}
         >
-          {this._renderThumbImage()}
+        {this._renderThumbImage(i)}
         </Animated.View>
+      );
+    }
+
+    for (let i = 0; i < thumbValues.length; i++) {
+      let thumb = thumbValues[i];
+
+      children.push(
         <View
+          key={'panhandlers_' + i}
           renderToHardwareTextureAndroid={true}
           style={[defaultStyles.touchArea, touchOverflowStyle]}
           {...this._panResponder.panHandlers}>
-          {debugTouchArea === true && this._renderDebugThumbTouchRect(thumbLeft)}
+          {debugTouchArea === true && this._renderDebugThumbTouchRect(thumb)}
         </View>
+      );
+    }
+
+    return (
+      <View {...other} style={[mainStyles.container, style]} onLayout={this._measureContainer}>
+
+        <View
+          style={[{backgroundColor: maximumTrackTintColor || trackColor}, mainStyles.track, trackStyle]}
+          renderToHardwareTextureAndroid={true}
+          onLayout={this._measureTrack} />
+
+        {children}
+
       </View>
     );
   };
@@ -302,57 +434,83 @@ export default class Slider extends PureComponent {
     return otherProps;
   };
 
-  _handleStartShouldSetPanResponder = (e: Object, /*gestureState: Object*/): boolean => {
+  _handleStartShouldSetPanResponder = (e/*, gestureState*/) => {
     // Should we become active when the user presses down on the thumb?
-    return this._thumbHitTest(e);
+    return this._thumbHitTest(e) !== -1;
   };
 
-  _handleMoveShouldSetPanResponder(/*e: Object, gestureState: Object*/): boolean {
+  _handleMoveShouldSetPanResponder(/*e, gestureState*/) {
     // Should we become active when the user moves a touch over the thumb?
     return false;
   };
 
-  _handlePanResponderGrant = (/*e: Object, gestureState: Object*/) => {
-    this._previousLeft = this._getThumbLeft(this._getCurrentValue());
-    this._fireChangeEvent('onSlidingStart');
+  _handlePanResponderGrant = (e/*, gestureState*/) => {
+
+    let hitIndex = this._thumbHitTest(e);
+
+    if (hitIndex === -1)
+      return false;
+
+    if (!this._trackingTouches) {
+      this._trackingTouches = {};
+    }
+
+    this._trackingTouches[e.nativeEvent.identifier] = {
+      index: hitIndex,
+      prevValue: this._getThumb(this._getThumbValue(hitIndex))
+    };
+
+    this._fireChangeEvent('onSlidingStart', hitIndex);
   };
 
-  _handlePanResponderMove = (e: Object, gestureState: Object) => {
+  _handlePanResponderMove = (e, gestureState) => {
     if (this.props.disabled) {
       return;
     }
 
-    this._setCurrentValue(this._getValue(gestureState));
-    this._fireChangeEvent('onValueChange');
+    let tracking = this._trackingTouches[e.nativeEvent.identifier];
+
+    let newValue = this._getValue(tracking.prevValue, gestureState);
+    if (tracking.index > 0)
+      newValue = Math.max(newValue, this._getThumbValue(tracking.index - 1));
+    if (tracking.index < this.state.value.length - 1)
+      newValue = Math.min(newValue, this._getThumbValue(tracking.index + 1));
+
+    this._setCurrentValue(newValue, tracking.index);
+
+    this._fireChangeEvent('onValueChange', tracking.index);
   };
 
-  _handlePanResponderRequestEnd(e: Object, gestureState: Object) {
+  _handlePanResponderRequestEnd(e, gestureState) {
     // Should we allow another component to take over this pan?
     return false;
   };
 
-  _handlePanResponderEnd = (e: Object, gestureState: Object) => {
-    if (this.props.disabled) {
+  _handlePanResponderEnd = (e, gestureState) => {
+
+    let tracking = this._trackingTouches[e.nativeEvent.identifier];
+    delete this._trackingTouches[e.nativeEvent.identifier];
+
+    if (this.props.disabled || !tracking) {
       return;
     }
 
-    this._setCurrentValue(this._getValue(gestureState));
-    this._fireChangeEvent('onSlidingComplete');
+    this._fireChangeEvent('onSlidingComplete', tracking.index);
   };
 
-  _measureContainer = (x: Object) => {
+  _measureContainer = (x) => {
     this._handleMeasure('containerSize', x);
   };
 
-  _measureTrack = (x: Object) => {
+  _measureTrack = (x) => {
     this._handleMeasure('trackSize', x);
   };
 
-  _measureThumb = (x: Object) => {
+  _measureThumb = (x) => {
     this._handleMeasure('thumbSize', x);
   };
 
-  _handleMeasure = (name: string, x: Object) => {
+  _handleMeasure = (name, x) => {
     var {width, height} = x.nativeEvent.layout;
     var size = {width: width, height: height};
 
@@ -373,20 +531,20 @@ export default class Slider extends PureComponent {
     }
   };
 
-  _getRatio = (value: number) => {
+  _getRatio = (value) => {
     return (value - this.props.minimumValue) / (this.props.maximumValue - this.props.minimumValue);
   };
 
-  _getThumbLeft = (value: number) => {
+  _getThumb = (value) => {
     var ratio = this._getRatio(value);
     return ratio * (this.state.containerSize.width - this.state.thumbSize.width);
   };
 
-  _getValue = (gestureState: Object) => {
+  _getValue = (value, gestureState) => {
     var length = this.state.containerSize.width - this.state.thumbSize.width;
-    var thumbLeft = this._previousLeft + gestureState.dx;
+    var thumb = value + gestureState.dx;
 
-    var ratio = thumbLeft / length;
+    var ratio = thumb / length;
 
     if (this.props.step) {
       return Math.max(this.props.minimumValue,
@@ -403,15 +561,30 @@ export default class Slider extends PureComponent {
     }
   };
 
-  _getCurrentValue = () => {
-    return this.state.value.__getValue();
+  _getThumbValue = (i) => {
+    return this.state.value[i].__getValue();
   };
 
-  _setCurrentValue = (value: number) => {
-    this.state.value.setValue(value);
+  _onAnimatedValueChange = (x) => {
+    if (this.state.value.length > 1) {
+      // We only need this in multi-thumb mode.
+      // If there was an Animated feature that allows min/max 
+      //   on multiple Animated values - we could remove this listener.
+
+      let flatValues = this.state.interpolatedThumbValues.map(x => x.__getValue());
+      this.state.minThumbValue.setValue(Math.min.apply(Math, flatValues));
+      this.state.maxThumbValue.setValue(Math.max.apply(Math, flatValues));
+    }
   };
 
-  _setCurrentValueAnimated = (value: number) => {
+  _setCurrentValue = (value, i) => {
+    if (typeof value !== 'number')
+      return;
+
+    this.state.value[i].setValue(value);
+  };
+
+  _setCurrentValueAnimated = (value, i) => {
     var animationType   = this.props.animationType;
     var animationConfig = Object.assign(
       {},
@@ -420,12 +593,12 @@ export default class Slider extends PureComponent {
       {toValue : value}
     );
 
-    Animated[animationType](this.state.value, animationConfig).start();
+    Animated[animationType](this.state.value[i], animationConfig).start();
   };
 
   _fireChangeEvent = (event) => {
     if (this.props[event]) {
-      this.props[event](this._getCurrentValue());
+      this.props[event].apply(this, this.state.value.map(x => x.__getValue()));
     }
   };
 
@@ -464,19 +637,30 @@ export default class Slider extends PureComponent {
     return touchOverflowStyle;
   };
 
-  _thumbHitTest = (e: Object) => {
+  _thumbHitTest = (e) => {
+
     var nativeEvent = e.nativeEvent;
-    var thumbTouchRect = this._getThumbTouchRect();
-    return thumbTouchRect.containsPoint(nativeEvent.locationX, nativeEvent.locationY);
+
+    let hitIndex = -1;
+
+    for (let i = 0; i < this.state.value.length; i++) {
+      let thumbRect = this._getThumbTouchRect(this._getThumb(this._getThumbValue(i)));
+      if (thumbRect.containsPoint(nativeEvent.locationX, nativeEvent.locationY)) {
+        hitIndex = i;
+        break;
+      }
+    }
+
+    return hitIndex;
   };
 
-  _getThumbTouchRect = () => {
+  _getThumbTouchRect = (thumbLocation) => {
     var state = this.state;
     var props = this.props;
     var touchOverflowSize = this._getTouchOverflowSize();
 
     return new Rect(
-      touchOverflowSize.width / 2 + this._getThumbLeft(this._getCurrentValue()) + (state.thumbSize.width - props.thumbTouchSize.width) / 2,
+      touchOverflowSize.width / 2 + thumbLocation + (state.thumbSize.width - props.thumbTouchSize.width) / 2,
       touchOverflowSize.height / 2 + (state.containerSize.height - props.thumbTouchSize.height) / 2,
       props.thumbTouchSize.width,
       props.thumbTouchSize.height
@@ -484,7 +668,7 @@ export default class Slider extends PureComponent {
   };
 
   _renderDebugThumbTouchRect = (thumbLeft) => {
-    var thumbTouchRect = this._getThumbTouchRect();
+    var thumbTouchRect = this._getThumbTouchRect(thumbLeft);
     var positionStyle = {
       left: thumbLeft,
       top: thumbTouchRect.y,
@@ -500,8 +684,22 @@ export default class Slider extends PureComponent {
     );
   };
 
-  _renderThumbImage = () => {
-    var {thumbImage} = this.props;
+  _renderThumbImage = (thumbIndex) => {
+    var {
+      thumbImage,
+      thumbView
+    } = this.props;
+
+    if (Array.isArray(thumbView)) {
+      thumbView = thumbView[thumbIndex];
+    }
+
+    if (thumbView)
+      return thumbView;
+      
+    if (Array.isArray(thumbImage)) {
+      thumbImage = thumbImage[thumbIndex];
+    }
 
     if (!thumbImage) return;
 


### PR DESCRIPTION
Now we can pass an array to `value` to achieve multiple thumbs.
`thumbImage` accepts an array also - to override individual thumbs.
There's a new `thumbView` property, that works like `thumbImage` but supplies the whole thumb View.

An idea I took from @doctadre's PR, is better naming for the following props:
`minimumTrackTintColor` is deprecated, use `trackHighlightColor`
`maximumTrackTintColor ` is deprecated, use `trackColor`