### PR TITLE
Don't set PanResponder if Slider is disabled

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -304,7 +304,7 @@ export default class Slider extends PureComponent {
 
   _handleStartShouldSetPanResponder = (e: Object, /*gestureState: Object*/): boolean => {
     // Should we become active when the user presses down on the thumb?
-    return this._thumbHitTest(e);
+    return !this.props.disabled && this._thumbHitTest(e);
   };
 
   _handleMoveShouldSetPanResponder(/*e: Object, gestureState: Object*/): boolean {
@@ -318,10 +318,6 @@ export default class Slider extends PureComponent {
   };
 
   _handlePanResponderMove = (e: Object, gestureState: Object) => {
-    if (this.props.disabled) {
-      return;
-    }
-
     this._setCurrentValue(this._getValue(gestureState));
     this._fireChangeEvent('onValueChange');
   };
@@ -332,10 +328,6 @@ export default class Slider extends PureComponent {
   };
 
   _handlePanResponderEnd = (e: Object, gestureState: Object) => {
-    if (this.props.disabled) {
-      return;
-    }
-
     this._setCurrentValue(this._getValue(gestureState));
     this._fireChangeEvent('onSlidingComplete');
   };


### PR DESCRIPTION
Currently, when the Slider is disabled, `onSlidingStart()` is called when the user touches the Slider, but `onSlidingComplete()` is never called. This behavior is a bit inconsistent.

With this PR, when Slider is disabled, the Slider will not register any touch events (neither `onSlidingStart()` nor `onSlidingComplete()` are called). Another solution is to call `onSlidingStart()` when the user touches the slider and `onSlidingComplete()` when the slider is released (regardless of whether the Slider is disabled).

I took my approach since when the Slider is disabled, no sliding can take place, so there's no concept of a slide "starting" or "completing." A benefit of the other approach is that it makes it easy to respond when a user tries to slide the Slider when it's disabled.

If you'd prefer approach #2, I'm happy to modify the PR.

If you think things are best how they are now, I think the README should be updated to clarify the behavior.