### PR TITLE
Fix warnings when used in react-native-web

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -228,6 +228,10 @@ export default class Slider extends PureComponent {
       trackStyle,
       thumbStyle,
       debugTouchArea,
+      onValueChange,
+      thumbTouchSize,
+      animationType,
+      animateTransitions,
       ...other
     } = this.props;
     var {value, containerSize, trackSize, thumbSize, allMeasured} = this.state;


### PR DESCRIPTION
Warning: React does not recognize the `animateTransitions` prop on a DOM element.
Warning: React does not recognize the `animationType` prop on a DOM element.
Warning: React does not recognize the `thumbTouchSize` prop on a DOM element.
Unknown event handler property `onValueChange`. It will be ignored.