### PR TITLE
Allow track to be pressed at a specific position to set the value of the slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ debugTouchArea        | bool     | Yes      | false                     | Set th
 animateTransitions    | bool     | Yes      | false                     | Set to true if you want to use the default 'spring' animation
 animationType         | string   | Yes      | 'timing'                  | Set to 'spring' or 'timing' to use one of those two types of animations with the default [animation properties](https://facebook.github.io/react-native/docs/animations.html).
 animationConfig       | object   | Yes      | undefined                 | Used to configure the animation parameters.  These are the same parameters in the [Animated library](https://facebook.github.io/react-native/docs/animations.html).
-trackPressable        | bool     | Yes      | false                     | Set to true to update the value whilst pressing the Slider
+trackPressable        | bool     | Yes      | false                     | Allow the value to be set at a specific position when the track is pressed
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ thumbImage            | [source](http://facebook.github.io/react-native/docs/ima
 debugTouchArea        | bool     | Yes      | false                     | Set this to true to visually see the thumb touch rect in green.
 animateTransitions    | bool     | Yes      | false                     | Set to true if you want to use the default 'spring' animation
 animationType         | string   | Yes      | 'timing'                  | Set to 'spring' or 'timing' to use one of those two types of animations with the default [animation properties](https://facebook.github.io/react-native/docs/animations.html).
-animationConfig       | object   | Yes      | undefined                 | Used to configure the animation parameters.  These are the same parameters in the [Animated library](https://facebook.github.io/react-native/docs/animations.html). 
+animationConfig       | object   | Yes      | undefined                 | Used to configure the animation parameters.  These are the same parameters in the [Animated library](https://facebook.github.io/react-native/docs/animations.html).
+trackPressable        | bool     | Yes      | false                     | Set to true to update the value whilst pressing the Slider
 
 
 ---

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -169,7 +169,7 @@ export default class Slider extends PureComponent {
     animationConfig: PropTypes.object,
 
     /**
-      * Set to true to update the value whilst pressing the Slider
+      * Allow the value to be set at a specific position when the track is pressed
       */
     trackPressable : PropTypes.bool,
   };

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -167,6 +167,11 @@ export default class Slider extends PureComponent {
      * Used to configure the animation parameters.  These are the same parameters in the Animated library.
      */
     animationConfig: PropTypes.object,
+
+    /**
+      * Set to true to update the value whilst pressing the Slider
+      */
+    trackPressable : PropTypes.bool,
   };
 
   static defaultProps = {
@@ -180,6 +185,7 @@ export default class Slider extends PureComponent {
     thumbTouchSize: { width: 40, height: 40 },
     debugTouchArea: false,
     animationType: 'timing',
+    trackPressable: false,
   };
 
   state = {
@@ -322,6 +328,7 @@ export default class Slider extends PureComponent {
       style,
       trackStyle,
       thumbStyle,
+      trackPressable,
       ...otherProps
     } = props;
 
@@ -332,15 +339,15 @@ export default class Slider extends PureComponent {
     e: Object /* gestureState: Object */,
   ): boolean =>
     // Should we become active when the user presses down on the thumb?
-    this._thumbHitTest(e);
+    this.props.trackPressable || this._thumbHitTest(e);
 
   _handleMoveShouldSetPanResponder(/* e: Object, gestureState: Object */): boolean {
     // Should we become active when the user moves a touch over the thumb?
     return false;
   }
 
-  _handlePanResponderGrant = (/* e: Object, gestureState: Object */) => {
-    this._previousLeft = this._getThumbLeft(this._getCurrentValue());
+  _handlePanResponderGrant = (e: Object/*, gestureState: Object */) => {
+    this._previousLeft = this.props.trackPressable ? e.nativeEvent.locationX - (this.props.thumbTouchSize.width/2) : this._getThumbLeft(this._getCurrentValue());
     this._fireChangeEvent('onSlidingStart');
   };
 


### PR DESCRIPTION
Picking up where #92 left off, this PR adds support for the slider being 'perusable', i.e. if the user taps on the slider track, the slider is set to the value at that position on the track.

This is opt-in behaviour via the `trackPressable` prop, which is set to `false` by default.

Thanks to @ajaswal for the original PR!