### PR TITLE
thumbStyle - transform

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -294,7 +294,10 @@ export default class Slider extends PureComponent {
             mainStyles.thumb,
             thumbStyle,
             {
-              transform: [{ translateX: thumbLeft }, { translateY: 0 }],
+              transform: [
+                { translateX: thumbLeft }, { translateY: 0 },
+                ...(thumbStyle && thumbStyle.transform || []),
+              ],
               ...valueVisibleStyle,
             },
           ]}


### PR DESCRIPTION
The transform style prop should not overwrite the user defined transform props.

<Slider thumbStyle={ transform: [{ scale: 2}] } /> 
will now work as expected.