### PR TITLE
Move ViewPropTypes from react-native to deprecated-react-native-prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "git@github.com:jeanregisser/react-native-slider.git"
   },
   "dependencies": {
+    "deprecated-react-native-prop-types": "^2.3.0",
     "prop-types": "^15.5.6"
   },
   "devDependencies": {

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -7,10 +7,9 @@ import {
   PanResponder,
   View,
   Easing,
-  ViewPropTypes,
-  I18nManager,
+  I18nManager
 } from 'react-native';
-
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 
 const TRACK_SIZE = 4;


### PR DESCRIPTION
Importing ViewPropTypes from react-native is throwing the below error and the project is not running.

`ERROR  Invariant Violation: ViewPropTypes has been removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'.`

This PR will move `ViewPropTypes` from 'react-native' to 'deprecated-react-native-prop-types' and should resolve this issue.